### PR TITLE
build(tsconfig): adjust root directory and exclude patterns

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2020",
     "module": "commonjs",
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -17,5 +17,5 @@
     "types": ["jest", "node"]
   },
   "include": ["src/**/*", "scripts/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Change 'rootDir' from './src' to './' to include files outside src
- Remove 'dist' and '**/*.test.ts' from exclude patterns to allow test files compilation
- Keep existing include patterns for src and scripts directories

This change enables TypeScript to process files in the project root and test files