### PR TITLE
feat(transactions): add endpoint to retrieve unique categories

### DIFF
--- a/backend/src/config/swagger.config.ts
+++ b/backend/src/config/swagger.config.ts
@@ -50,6 +50,13 @@ const options = {
             },
           },
         },
+        CategoriesList: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          description: 'List of unique categories from user transactions',
+        },
         Transaction: {
           type: 'object',
           properties: {

--- a/backend/src/controllers/transaction.controller.ts
+++ b/backend/src/controllers/transaction.controller.ts
@@ -33,6 +33,19 @@ class TransactionController {
       next(error);
     }
   }
+
+  async getCategories(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        throw new Error('User not authenticated');
+      }
+      const categories = await TransactionService.getCategories(userId);
+      res.status(200).json(categories);
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 export default new TransactionController();

--- a/backend/src/routes/transaction.routes.ts
+++ b/backend/src/routes/transaction.routes.ts
@@ -107,4 +107,30 @@ router.post('/', validateTransaction, TransactionController.createTransaction);
  */
 router.get('/', validateTransactionFilters, TransactionController.listTransactions);
 
+/**
+ * @openapi
+ * /api/v1/transactions/categories:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Transactions
+ *     summary: Get unique categories from user transactions
+ *     description: Retrieve a list of unique categories from user's transactions. Requires authentication.
+ *     responses:
+ *       200:
+ *         description: List of unique categories
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CategoriesList'
+ *       401:
+ *         description: Unauthorized - Invalid or missing token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get('/categories', TransactionController.getCategories);
+
 export default router;

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -74,6 +74,16 @@ class TransactionService {
       amount: transaction.amount.toNumber(),
     }));
   }
+
+  async getCategories(userId: string): Promise<string[]> {
+    const transactions = await prisma.transaction.findMany({
+      where: {
+        userId,
+      },
+    });
+    const categories = [...new Set(transactions.map((t) => t.category))];
+    return categories;
+  }
 }
 
 export default new TransactionService();


### PR DESCRIPTION
- Add new GET '/api/v1/transactions/categories' endpoint to fetch unique transaction categories
- Implement TransactionService method to get distinct categories for a user
- Add Swagger documentation and schema for categories endpoint
- Update controller with new getCategories method

This change allows clients to fetch a list of all unique categories used in a user's transactions, which is useful for building category filters and dropdowns in the UI.